### PR TITLE
feat: add cli script to run from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,59 @@ sum(log(((distribution bin counts + 1) / sum(distribution bin counts + 1))^user 
 ```
 The addition of one to each bin ensures that there are no bins lacking data.
 
+### CLI
+
+A command line interface (CLI) is available for this application. The CLI is a Python script. You can install the necessary packages with conda using the following command:
+
+```sh
+conda env create -f environment.yaml
+```
+
+Here is an example of how to run the CLI with a list of mutations and the output you can expect:
+
+```sh
+$ python covid_mutation_distribution/cli.py "C241T, C3037T, A23403G, G28881A, G28882A, G28883C"
+Number of mutations: 6
+Transition/Transversion ratio: 5.00
+
+Log Likelihoods:
+  chronic: -11.04
+  total chronic: -11.50
+  deer: -12.92
+  total deer: -12.11
+
+Best fit distribution: (np.float64(-11.040868182380382), 'global_pre-VoC')
+(1.58 times more likely than the global Omicron distribution)
+
+Mutator lineage analysis:
+  No mutator lineage detected
+```
+
+Full usage information can be found by running:
+
+```txt
+usage: cli.py [-h] [--bin-size {genes_split,gene,500,1000}] [--output {text,json}] [--plot] [--plot-output PLOT_OUTPUT] [--color-palette {plasma,viridis,inferno,seaborn}] [--verbose] mutations
+
+SARS-CoV-2 Mutation Distribution Profiler (SMDP) CLI
+
+positional arguments:
+  mutations             Comma-separated list of mutations or path to a file containing mutations
+
+options:
+  -h, --help            show this help message and exit
+  --bin-size {genes_split,gene,500,1000}
+                        Bin size for analysis (default: gene)
+  --output {text,json}  Output format (default: text)
+  --plot                Generate a plot of mutation distribution
+  --plot-output PLOT_OUTPUT
+                        Output file for the plot (default: mutation_distribution.png)
+  --color-palette {plasma,viridis,inferno,seaborn}
+                        Color palette for the plot (default: plasma)
+  --verbose             Print detailed information during analysis
+```
+
+Currently, the CLI only supports a single query at a time.
+
 ## Notes on Input
 - Your list can be formatted **with** or **without** nucleotide abbreviations. e.g. `C897A, G3431T, A7842G, C8293T,...`  OR `897, 3431, 7842, 8293,...`
 - These coordinates MUST be **genomic** coordinates, **not gene** coordinates like `S:G107Y`

--- a/covid_mutation_distribution/cli.py
+++ b/covid_mutation_distribution/cli.py
@@ -1,0 +1,228 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import functions
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="SARS-CoV-2 Mutation Distribution Profiler (SMDP) CLI"
+    )
+    parser.add_argument(
+        "mutations",
+        help="Comma-separated list of mutations or path to a file containing mutations",
+    )
+    parser.add_argument(
+        "--bin-size",
+        choices=["genes_split", "gene", "500", "1000"],
+        default="gene",
+        help="Bin size for analysis (default: gene)",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "--plot", action="store_true", help="Generate a plot of mutation distribution"
+    )
+    parser.add_argument(
+        "--plot-output",
+        default="mutation_distribution.png",
+        help="Output file for the plot (default: mutation_distribution.png)",
+    )
+    parser.add_argument(
+        "--color-palette",
+        choices=["plasma", "viridis", "inferno", "seaborn"],
+        default="plasma",
+        help="Color palette for the plot (default: plasma)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print detailed information during analysis",
+    )
+    return parser.parse_args()
+
+
+def load_mutations(mutations_input: str) -> List[str]:
+    is_file = False
+    try:
+        is_file = Path(mutations_input).is_file()
+    except OSError as e:
+        print(f"Error: Unable to read mutations as file: {e}")
+    if is_file:
+        with open(mutations_input, "r") as f:
+            mutations = f.read().strip()
+    else:
+        mutations = mutations_input
+    return functions.parse_user_input(mutations)
+
+
+def load_distribution_data() -> Dict[str, Tuple[List[int], int]]:
+    data_dir = Path(__file__).parent / "data"
+    distributions = {
+        "chronic": "chronicnucl.tsv",
+        "deer": "deernucl.tsv",
+        "global": "globalnucl.tsv",
+        "global_late": "globallatenucl.tsv",
+    }
+
+    data = {}
+    for name, filename in distributions.items():
+        file_path = data_dir / filename
+        data[name], data[f"total_{name}"] = functions.parse_mutation_files(file_path)
+
+    return data
+
+
+def calculate_likelihoods(
+    bin_size: str,
+    mutations: List[str],
+    distribution_data: Dict[str, Tuple[List[int], int]],
+) -> Tuple[List[Tuple[float, str]], str]:
+    likelihood_list, most_likely = functions.most_likely(
+        bin_size,
+        distribution_data["global"],
+        distribution_data["global_late"],
+        distribution_data["chronic"],
+        distribution_data["deer"],
+        mutations,
+    )
+    return likelihood_list, most_likely
+
+
+def analyze_mutations(
+    mutations: str, bin_size: str, verbose: bool
+) -> Tuple[Dict[str, any], List[str], Dict[str, Tuple[List[int], int]]]:
+    mut_list = load_mutations(mutations)
+    transitions, transversions = functions.transition_or_transversion(mutations)
+
+    if verbose:
+        print(f"Analyzing {len(mut_list)} mutations...")
+        print(f"Transitions: {transitions}, Transversions: {transversions}")
+
+    distribution_data = load_distribution_data()
+    likelihood_list, most_likely = calculate_likelihoods(
+        bin_size, mutations, distribution_data
+    )
+
+    results = {
+        "mutations_count": len(mut_list),
+        "transition_transversion_ratio": transitions / transversions
+        if transversions
+        else None,
+        "likelihoods": {
+            dist.replace("_", " "): likelihood[0]
+            for dist, likelihood in zip(distribution_data.keys(), likelihood_list)
+        },
+        "best_fit": most_likely,
+        "times_more_likely": functions.times_more_likely(likelihood_list)[0],
+        "compared_to": functions.times_more_likely(likelihood_list)[1].replace(
+            "_", " "
+        ),
+        "mutator_lineage": functions.mut_lineage_parsing(mutations),
+    }
+
+    if verbose:
+        print("Analysis complete.")
+
+    return results, mut_list, distribution_data
+
+
+def print_results(results: Dict[str, any]) -> None:
+    print(f"Number of mutations: {results['mutations_count']}")
+    print(
+        f"Transition/Transversion ratio: {results['transition_transversion_ratio']:.2f}"
+    )
+    print("\nLog Likelihoods:")
+    for dist, likelihood in results["likelihoods"].items():
+        print(f"  {dist}: {likelihood:.2f}")
+    print(f"\nBest fit distribution: {results['best_fit']}")
+    print(
+        f"({results['times_more_likely']:.2f} times more likely than the {results['compared_to']} distribution)"
+    )
+
+    print("\nMutator lineage analysis:")
+    if results["mutator_lineage"][0]:
+        print(f"  Confirmed: {results['mutator_lineage'][0]}")
+    if results["mutator_lineage"][1]:
+        print(f"  Potential: {results['mutator_lineage'][1]}")
+    if not any(results["mutator_lineage"]):
+        print("  No mutator lineage detected")
+
+
+def generate_plot(
+    mut_list: List[str],
+    bin_size: str,
+    distribution_data: Dict[str, Tuple[List[int], int]],
+    color_palette: str,
+    output_file: str,
+) -> None:
+    try:
+        import matplotlib.pyplot as plt
+        import seaborn as sns
+    except ImportError:
+        print(
+            "Error: matplotlib and seaborn are required for plotting. Please install them and try again."
+        )
+        return
+
+    counts, bins = functions.make_bins(mut_list, bin_size)
+
+    plt.figure(figsize=(12, 6))
+    sns.set_style("whitegrid")
+    sns.set_palette(color_palette)
+
+    for name, data in distribution_data.items():
+        if not name.startswith("total_"):
+            dist_counts, _ = functions.make_bins(data, bin_size)
+            total = distribution_data[f"total_{name}"]
+            plt.plot(
+                bins, [x / total for x in dist_counts], label=name.replace("_", " ")
+            )
+
+    plt.plot(
+        bins, [x / len(mut_list) for x in counts], label="input mutations", linewidth=2
+    )
+
+    plt.xlabel("Genome Position")
+    plt.ylabel("Proportion of Mutations")
+    plt.title("Distribution of Mutations Across Genome")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(output_file)
+    print(f"Plot saved as {output_file}")
+
+
+def main() -> None:
+    args = parse_arguments()
+
+    if args.plot and args.bin_size not in ["500", "1000"]:
+        print("Error: Plotting is only available for integer bin sizes. Set `--bin-size` to 500 or 1000 to plot.")
+        exit(1)
+
+    results, mut_list, distribution_data = analyze_mutations(
+        args.mutations, args.bin_size, args.verbose
+    )
+
+    if args.output == "text":
+        print_results(results)
+    elif args.output == "json":
+        print(json.dumps(results, indent=2))
+
+    if args.plot:
+        generate_plot(
+            mut_list,
+            args.bin_size,
+            distribution_data,
+            args.color_palette,
+            args.plot_output,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/covid_mutation_distribution/cli.py
+++ b/covid_mutation_distribution/cli.py
@@ -9,8 +9,8 @@ import functions
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="""SMDP: SARS-CoV-2 Mutation Distribution Profiler for rapid estimation of mutational histories.
-Developed by the CAMEO team of CoVaRR-Net.
 
+Erin E. Gill, Sheri Harari, Aijing Feng, Fiona S.L. Brinkman, Sarah Otto
 For the web app, visit: https://eringill.shinyapps.io/covid_mutation_distributions/
 Source code: https://github.com/eringill/chronic_infection_python
 Please cite: https://doi.org/10.48550/arXiv.2407.11201""",

--- a/covid_mutation_distribution/cli.py
+++ b/covid_mutation_distribution/cli.py
@@ -8,7 +8,13 @@ import functions
 
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="SARS-CoV-2 Mutation Distribution Profiler (SMDP) CLI"
+        description="""SMDP: SARS-CoV-2 Mutation Distribution Profiler for rapid estimation of mutational histories.
+Developed by the CAMEO team of CoVaRR-Net.
+
+For the web app, visit: https://eringill.shinyapps.io/covid_mutation_distributions/
+Source code: https://github.com/eringill/chronic_infection_python
+Please cite: https://doi.org/10.48550/arXiv.2407.11201""",
+        formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument(
         "mutations",
@@ -202,7 +208,9 @@ def main() -> None:
     args = parse_arguments()
 
     if args.plot and args.bin_size not in ["500", "1000"]:
-        print("Error: Plotting is only available for integer bin sizes. Set `--bin-size` to 500 or 1000 to plot.")
+        print(
+            "Error: Plotting is only available for integer bin sizes. Set `--bin-size` to 500 or 1000 to plot."
+        )
         exit(1)
 
     results, mut_list, distribution_data = analyze_mutations(

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,9 @@
+name: smdpcli
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python
+  - pandas
+  - matplotlib
+  - seaborn


### PR DESCRIPTION
I generated this script by asking Claude 3.5 Sonnet to generate a CLI from the shiny app code.

I then of course reviewed and fixed the few bugs.

In the future, it'd be easy to also optionally take a fasta file, run nextclade and use nextclade results as mutation input.

As an overview, here is what I added to the README, reproduced for convenience:


### CLI

A command line interface (CLI) is available for this application. The CLI is a Python script. You can install the necessary packages with conda using the following command:

```sh
conda env create -f environment.yaml
```

Here is an example of how to run the CLI with a list of mutations and the output you can expect:

```sh
$ python covid_mutation_distribution/cli.py "C241T, C3037T, A23403G, G28881A, G28882A, G28883C"
Number of mutations: 6
Transition/Transversion ratio: 5.00

Log Likelihoods:
  chronic: -11.04
  total chronic: -11.50
  deer: -12.92
  total deer: -12.11

Best fit distribution: (np.float64(-11.040868182380382), 'global_pre-VoC')
(1.58 times more likely than the global Omicron distribution)

Mutator lineage analysis:
  No mutator lineage detected
```

Full usage information can be found by running:

```txt
usage: cli.py [-h] [--bin-size {genes_split,gene,500,1000}] [--output {text,json}] [--plot] [--plot-output PLOT_OUTPUT] [--color-palette {plasma,viridis,inferno,seaborn}] [--verbose] mutations

SARS-CoV-2 Mutation Distribution Profiler (SMDP) CLI

positional arguments:
  mutations             Comma-separated list of mutations or path to a file containing mutations

options:
  -h, --help            show this help message and exit
  --bin-size {genes_split,gene,500,1000}
                        Bin size for analysis (default: gene)
  --output {text,json}  Output format (default: text)
  --plot                Generate a plot of mutation distribution
  --plot-output PLOT_OUTPUT
                        Output file for the plot (default: mutation_distribution.png)
  --color-palette {plasma,viridis,inferno,seaborn}
                        Color palette for the plot (default: plasma)
  --verbose             Print detailed information during analysis
```

Currently, the CLI only supports a single query at a time.

Resolves #13 